### PR TITLE
Addition of more query string features

### DIFF
--- a/lib/lucene_query_parser/parser.rb
+++ b/lib/lucene_query_parser/parser.rb
@@ -44,7 +44,7 @@ module LuceneQueryParser
 
     rule :expr do
       space.maybe >>
-      operand >> (space >> (operator >> space >> operand | operand)).repeat >>
+      operand >> (space.maybe >> (operator >> space.maybe >> operand | operand)).repeat >>
       space.maybe
     end
 

--- a/lib/lucene_query_parser/parser.rb
+++ b/lib/lucene_query_parser/parser.rb
@@ -76,6 +76,7 @@ module LuceneQueryParser
 
     rule :group do
       str('(') >> space.maybe >> expr.as(:group) >> space.maybe >> str(')')
+      boost.maybe
     end
 
     rule :field do

--- a/lib/lucene_query_parser/parser.rb
+++ b/lib/lucene_query_parser/parser.rb
@@ -132,7 +132,7 @@ module LuceneQueryParser
     end
 
     rule :space do
-      match["\n \t\u00a0"].repeat(1)
+      match["\n \t\u00a0\u200B"].repeat(1)
     end
 
   end

--- a/lib/lucene_query_parser/parser.rb
+++ b/lib/lucene_query_parser/parser.rb
@@ -49,7 +49,7 @@ module LuceneQueryParser
     end
 
     rule :operator do
-      str('AND').as(:op) | str('OR').as(:op)
+      str('AND').as(:op) | str('OR').as(:op) | str('&&').as(:op) | str('||').as(:op)
     end
 
     rule :operand do

--- a/lib/lucene_query_parser/parser.rb
+++ b/lib/lucene_query_parser/parser.rb
@@ -71,7 +71,7 @@ module LuceneQueryParser
     end
 
     rule :distance do
-      str('~') >> match['0-9'].repeat(1).as(:distance)
+      space.maybe >> str('~') >> match['0-9'].repeat(1).as(:distance)
     end
 
     rule :group do
@@ -107,12 +107,12 @@ module LuceneQueryParser
     end
 
     rule :fuzzy do
-      str('~') >>
+      space.maybe >> str('~') >>
       ( str('0.') >> match['0-9'].repeat(1) | match['01'] ).maybe.as(:similarity)
     end
 
     rule :boost do
-      str('^') >> (
+      space.maybe >> str('^') >> (
         str('0.') >> match['0-9'].repeat(1) |
         match['0-9'].repeat(1)
       ).as(:boost)

--- a/lib/lucene_query_parser/parser.rb
+++ b/lib/lucene_query_parser/parser.rb
@@ -103,6 +103,7 @@ module LuceneQueryParser
     rule :unary_operator do
       str('+').as(:required) |
       str('-').as(:prohibited) |
+      str('!').as(:prohibited) |
       (str('NOT').as(:op) >> space)
     end
 

--- a/lib/lucene_query_parser/parser.rb
+++ b/lib/lucene_query_parser/parser.rb
@@ -132,7 +132,7 @@ module LuceneQueryParser
     end
 
     rule :space do
-      match["\n \t"].repeat(1)
+      match["\n \t\u00a0"].repeat(1)
     end
 
   end

--- a/lib/lucene_query_parser/parser.rb
+++ b/lib/lucene_query_parser/parser.rb
@@ -75,7 +75,7 @@ module LuceneQueryParser
     end
 
     rule :group do
-      str('(') >> space.maybe >> expr.as(:group) >> space.maybe >> str(')')
+      str('(') >> space.maybe >> expr.as(:group) >> space.maybe >> str(')') >>
       boost.maybe
     end
 

--- a/lib/lucene_query_parser/parser.rb
+++ b/lib/lucene_query_parser/parser.rb
@@ -29,7 +29,7 @@ module LuceneQueryParser
         # must define :term rule at run-time so that it can include
         # the term_re_str
         self.class.rule :term do
-          match[term_re_str].repeat(1).as(:term) >> (fuzzy | boost).maybe
+          ( (escape_special_words | match[term_re_str]).repeat(1) ).as(:term) >> (fuzzy | boost).maybe
         end
       else
         self.class.rule :term do

--- a/lib/lucene_query_parser/parser.rb
+++ b/lib/lucene_query_parser/parser.rb
@@ -70,10 +70,6 @@ module LuceneQueryParser
       (distance | boost).maybe
     end
 
-    rule :distance do
-      space.maybe >> str('~') >> match['0-9'].repeat(1).as(:distance)
-    end
-
     rule :group do
       str('(') >> space.maybe >> expr.as(:group) >> space.maybe >> str(')') >>
       boost.maybe
@@ -107,13 +103,17 @@ module LuceneQueryParser
       (str('NOT').as(:op) >> space)
     end
 
+    rule :distance do
+      space.maybe >> str('~') >> space.maybe >> match['0-9'].repeat(1).as(:distance)
+    end
+
     rule :fuzzy do
       space.maybe >> str('~') >>
       ( str('0.') >> match['0-9'].repeat(1) | match['01'] ).maybe.as(:similarity)
     end
 
     rule :boost do
-      space.maybe >> str('^') >> (
+      space.maybe >> str('^') >> space.maybe >> (
         str('0.') >> match['0-9'].repeat(1) |
         match['0-9'].repeat(1)
       ).as(:boost)

--- a/lib/lucene_query_parser/parser.rb
+++ b/lib/lucene_query_parser/parser.rb
@@ -53,7 +53,7 @@ module LuceneQueryParser
     end
 
     rule :operand do
-      unary_operator.maybe >> (
+      unary_operator.maybe >> space.maybe >> (
         group |
         field |
         term |

--- a/spec/lucene_query_parser/parser_spec.rb
+++ b/spec/lucene_query_parser/parser_spec.rb
@@ -162,6 +162,13 @@ describe LuceneQueryParser::Parser do
       ]
     end
 
+    it "parses NOTs with a group" do
+      should parse("foo NOT (bar coca)").as [
+        {:term => "foo"},
+        {:group => [{:term => "bar"}, {:term => "coca"}], :op => "NOT"}
+      ]
+    end
+
     it "parses negation in terms" do
       should parse("foo !bar").as [
         {:term => "foo"},
@@ -321,6 +328,12 @@ describe LuceneQueryParser::Parser do
       should parse('fo?').as( {:term => 'fo?'} )
     end
 
+    it "parses non-breaking space" do
+      should parse("foo bar").as [ # do not be fooled, there is a non-breaking space between foo and bar
+        {:term => "foo"},
+        {:term => "bar"},
+      ]
+    end
   end
 
   describe "#error_location" do

--- a/spec/lucene_query_parser/parser_spec.rb
+++ b/spec/lucene_query_parser/parser_spec.rb
@@ -62,9 +62,27 @@ describe LuceneQueryParser::Parser do
       )
     end
 
+    it "parses a nearness query (forgiving)" do
+      should parse(%q("foo bar" ~2)).as(
+        {:phrase => "foo bar", :distance => "2"}
+      )
+    end
+
     it "parses a paren grouping" do
       should parse(%q((foo bar))).as(
         {:group => [{:term => "foo"}, {:term => "bar"}]}
+      )
+    end
+
+    it "parses boosts in groupings" do
+      should parse('(foo bar)^5').as(
+        {:group => [{:term => "foo"}, {:term => "bar"}], :boost => "5"}
+      )
+    end
+
+    it "parses boosts in groupings (forgiving)" do
+      should parse('(foo bar) ^5').as(
+        {:group => [{:term => "foo"}, {:term => "bar"}], :boost => "5"}
       )
     end
 
@@ -172,6 +190,18 @@ describe LuceneQueryParser::Parser do
     it "parses a fuzzy similarity of 0.8" do
       should parse('fuzzy~0.8').as(
         {:term => "fuzzy", :similarity => "0.8"}
+      )
+    end
+
+    it "parses a boost on phrase" do
+      should parse('"some phrase"^3').as(
+        {:phrase => "some phrase", :boost => "3"}
+      )
+    end
+
+    it "parses a boost on phrase (forgiving)" do
+      should parse('"some phrase" ^3').as(
+        {:phrase => "some phrase", :boost => "3"}
       )
     end
 

--- a/spec/lucene_query_parser/parser_spec.rb
+++ b/spec/lucene_query_parser/parser_spec.rb
@@ -128,8 +128,30 @@ describe LuceneQueryParser::Parser do
       should parse("+foo").as({:term => "foo", :required => "+"})
     end
 
+    it "parses a required term (lenient)" do
+      should parse("+ foo").as({:term => "foo", :required => "+"})
+    end
+
+    it "parses a required term (lenient) v2" do
+      should parse("foo + bar").as([
+        {:term => "foo"},
+        {:term => "bar", :required => "+"}
+      ])
+    end
+
     it "parses a prohibited term" do
       should parse("-foo").as({:term => "foo", :prohibited => "-"})
+    end
+
+    it "parses a prohibited term (lenient)" do
+      should parse("- foo").as({:term => "foo", :prohibited => "-"})
+    end
+
+    it "parses a prohibited term (lenient) v2" do
+      should parse("foo - bar").as([
+        {:term => "foo"},
+        {:term => "bar", :prohibited => "-"}
+      ])
     end
 
     it "parses prohibited groups and phrases" do

--- a/spec/lucene_query_parser/parser_spec.rb
+++ b/spec/lucene_query_parser/parser_spec.rb
@@ -74,6 +74,20 @@ describe LuceneQueryParser::Parser do
       )
     end
 
+    it "parses grouping side by side with space" do
+      should parse('(foo bar) (lorem ipsum)').as([
+        {:group => [{:term => "foo"}, {:term => "bar"}]},
+        {:group => [{:term => "lorem"}, {:term => "ipsum"}]}
+      ])
+    end
+
+    it "parses grouping side by side with no space" do
+      should parse('(foo bar)(lorem ipsum)').as([
+        {:group => [{:term => "foo"}, {:term => "bar"}]},
+        {:group => [{:term => "lorem"}, {:term => "ipsum"}]}
+      ])
+    end
+
     it "parses boosts in groupings" do
       should parse('(foo bar)^5').as(
         {:group => [{:term => "foo"}, {:term => "bar"}], :boost => "5"}

--- a/spec/lucene_query_parser/parser_spec.rb
+++ b/spec/lucene_query_parser/parser_spec.rb
@@ -148,6 +148,34 @@ describe LuceneQueryParser::Parser do
       ]
     end
 
+    it "parses negation in terms" do
+      should parse("foo !bar").as [
+        {:term => "foo"},
+        {:term => "bar", :prohibited => "!"}
+      ]
+    end
+
+    it "parses negation in groupings" do
+      should parse('!(foo bar)^5').as(
+        {:group => [{:term => "foo"}, {:term => "bar"}], :prohibited => "!", :boost => "5"}
+      )
+    end
+
+    it "parses negation in phrases" do
+      q = %q(!"foo bar" isn't one)
+      should parse(q).as [
+        {:phrase => "foo bar", :prohibited => "!"},
+        {:term => "isn't"},
+        {:term => "one"}
+      ]
+    end
+
+    it "parses negation in field:value" do
+      should parse("!title:foo").as(
+        {:field => "title", :term => "foo", :prohibited => "!"}
+      )
+    end
+
     it "parses field:value" do
       should parse("title:foo").as(
         {:field => "title", :term => "foo"}

--- a/spec/lucene_query_parser/parser_spec.rb
+++ b/spec/lucene_query_parser/parser_spec.rb
@@ -146,6 +146,20 @@ describe LuceneQueryParser::Parser do
       ]
     end
 
+    it "parses && groupings" do
+      should parse(%q(foo && bar)).as [
+        {:term => "foo"},
+        {:op => "&&", :term => "bar"}
+      ]
+    end
+
+    it "parses || groupings" do
+      should parse(%q(foo || bar)).as [
+        {:term => "foo"},
+        {:op => "||", :term => "bar"}
+      ]
+    end
+
     it "parses a sequence of AND and OR" do
       should parse(%q(foo AND bar OR baz OR mumble)).as [
         {:term => "foo"},

--- a/spec/lucene_query_parser/parser_spec.rb
+++ b/spec/lucene_query_parser/parser_spec.rb
@@ -68,6 +68,12 @@ describe LuceneQueryParser::Parser do
       )
     end
 
+    it "parses a nearness query (even more forgiving)" do
+      should parse(%q("foo bar" ~ 2)).as(
+        {:phrase => "foo bar", :distance => "2"}
+      )
+    end
+
     it "parses a paren grouping" do
       should parse(%q((foo bar))).as(
         {:group => [{:term => "foo"}, {:term => "bar"}]}
@@ -96,6 +102,12 @@ describe LuceneQueryParser::Parser do
 
     it "parses boosts in groupings (forgiving)" do
       should parse('(foo bar) ^5').as(
+        {:group => [{:term => "foo"}, {:term => "bar"}], :boost => "5"}
+      )
+    end
+
+    it "parses boosts in groupings (even more forgiving)" do
+      should parse('(foo bar) ^ 5').as(
         {:group => [{:term => "foo"}, {:term => "bar"}], :boost => "5"}
       )
     end


### PR DESCRIPTION
- [x] add boosting for groups
  - [x] add testing for boosting for groups
- [x] support `"some distance phrase"    ~10` (the spaces between)
  - [x] add tests
- [x] support `"some boost phrase"    ^10` (the spaces between)
  - [x] add tests
- [x] support `(some boost phrase)    ^10` (the spaces between)
  - [x] add tests
- [x] support negation with a bang (eg. `!"this term`)
  - [x] add tests
- [x] spaces between operands should be optional
  - [x] add tests
- [ ] ~~support blank search (eg. `''`)~~
  - [ ] ~~add tests~~
